### PR TITLE
fixed issue where forever-typecheck polls incorrect file

### DIFF
--- a/forever-typecheck
+++ b/forever-typecheck
@@ -2,6 +2,6 @@
 
 while :
 do
-    runhaskell Test/LCSU.hs
-    inotifywait -e modify  ./Test/LCSU.hs
+    runhaskell test/Lcsu.hs
+    inotifywait -e modify  ./test/Lcsu.hs
 done


### PR DESCRIPTION
forever-typecheck was failing while looking for `LCSU.hs`. Presumably this had not been updated since some filename change
