### PR TITLE
added the cabal sandbox files to the git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+cabal.sandbox.config
+.cabal-sandbox


### PR DESCRIPTION
It is a lot better to have sandboxes set up when you have piles of different package versions for different haskell projects all kicking around. It would be silly to have all of the package binaries you need to compile a library getting versioned around with the library itself. 
