### PR TITLE
unit TH: ability to parse dimensionless units.

### DIFF
--- a/Data/Metrology/Parser/Internal.hs
+++ b/Data/Metrology/Parser/Internal.hs
@@ -110,12 +110,15 @@ lexer1 :: Lexer Token
 lexer1 = unitL <|> opL <|> numberL
 
 lexer :: Lexer [Token]
-lexer = do { eof <?> "" ; return [] } <|> do
-  spaces
-  tok <- lexer1
-  spaces
-  toks <- lexer
-  return (tok : toks)
+lexer = try lex1 <|> lex0
+  where
+    lex0 = do { spaces <?> "" ; return [] }
+    lex1 = do
+      spaces
+      tok <- lexer1
+      spaces
+      toks <- lexer
+      return (tok : toks)
 
 lex :: String -> Either ParseError [Token]
 lex = parse lexer ""
@@ -312,7 +315,7 @@ parser = do
   return result
   where
     dimless :: Exp
-    dimless = VarE 'DM.Number
+    dimless = ConE 'DM.Number
 
 -- top-level interface
 parseUnit :: SymbolTable -> String -> Either String Exp

--- a/Tests/Compile/UnitParser.hs
+++ b/Tests/Compile/UnitParser.hs
@@ -10,6 +10,9 @@ import Tests.Compile.UnitParser.Quoters ( ms )
 import Data.Metrology.SI
 import Data.Metrology
 
+frac1 :: Count
+frac1 =  0.78 % [ms|  |]
+
 len1, len2 :: Length
 len1 = 5 % [ms| m |]
 len2 = redim $ 10 % [ms| s km / ms |]


### PR DESCRIPTION
I'd like our unit TH to be able to parse dimensionless units.
And I think dimensionless unit should allow spaces like `[si|    |]` , since the behavior is consistent with allowing extra spaces among unit symbol and numbers.
