### PR TITLE
Added VectorSpace instance for Qu.

### DIFF
--- a/Data/Metrology/Qu.hs
+++ b/Data/Metrology/Qu.hs
@@ -22,6 +22,8 @@ import Data.Metrology.Units
 import Data.Metrology.Z
 import Data.Metrology.LCSU
 
+import Data.VectorSpace
+
 -------------------------------------------------------------
 --- Internal ------------------------------------------------
 -------------------------------------------------------------
@@ -206,6 +208,11 @@ qCubeRoot = qNthRoot sThree
 
 deriving instance Eq n => Eq (Qu d l n)
 deriving instance Ord n => Ord (Qu d l n)
+
+deriving instance AdditiveGroup n => AdditiveGroup (Qu d l n)
+instance VectorSpace n => VectorSpace (Qu d l n) where
+  type Scalar (Qu d l n) = Scalar n
+  a *^ (Qu b) = Qu (a *^ b)
 
 -------------------------------------------------------------
 --- Instances for dimensionless quantities ------------------


### PR DESCRIPTION
Not sure if anybody has suggested this before... it certainly seems an obvious thing to do.

Main benefit is that it allows to introduce units into code that uses generic vector operations, without any changes to the used operators. Also, you get to use linear maps to dimensional quantities.
(Not _from_ `Qu`, though, that would require `HasBasis`. Which might in fact also be feasible &ndash; again `type Basis Qu d l n = Basis n`... but this one is a bit more questionable, as the basis-vectors would have to refer to the canonical unit. Should be safe enough, though.)

I hope I haven't overlooked any problems with this proposal. At least the tests run just fine.

### Outlook

What would be really interesting is if we had a proper `DualSpace` type family, so we could implement a sort of `InnerSpace`-thing with units (dual space vectors have inverse unit). Perhaps I'll suggest adding something like that to the `vector-space` library.