### PR TITLE
Add dependency on lens

### DIFF
--- a/units.cabal
+++ b/units.cabal
@@ -65,6 +65,7 @@ library
                , syb >= 0.3
                , containers >= 0.4
                , units-parser >= 0.1 && < 1.0
+               , lens >= 4 && < 5
   exposed-modules:    
     Data.Metrology, 
     Data.Metrology.Internal,
@@ -111,6 +112,7 @@ test-suite main
                   , syb >= 0.3
                   , containers >= 0.4
                   , units-parser >= 0.1 && < 1.0
+                  , lens >= 4 && < 5
   hs-source-dirs:   units-defs, .
 
     -- optimize compile time, not runtime!


### PR DESCRIPTION
Add build dependency on the lens package, required by later changes in #45.