### PR TITLE
Bump linear version

### DIFF
--- a/units.cabal
+++ b/units.cabal
@@ -58,7 +58,7 @@ library
                , th-desugar >= 1.5.4
                , singletons >= 0.9 && < 3
                , vector-space >= 0.8
-               , linear >= 1.16.2
+               , linear >= 1.20.4
                , template-haskell
                , mtl >= 1.1
                , multimap >= 1.2


### PR DESCRIPTION
The current Travis build failure is caused by linear < 1.20.4 being incompatible to base-orphans > 0.5 (see the linear changelog).
Bumping the lower version bound on linear to 1.20.4 should fix the build, but I haven't tested this yet.

Note: There are further (GHC 8) compatibility improvements incoming for linear-1.20.5, see ekmett/linear#97.