### PR TITLE
Have UnitFactor require its units be Units

### DIFF
--- a/Data/Metrology/Units.hs
+++ b/Data/Metrology/Units.hs
@@ -132,9 +132,13 @@ instance ( False ~ IsCanonical noncanonical_unit
 -- Conversion ratios for lists of units
 -----------------------------------------------------------------------
 
+type family Units (dfactors :: [Factor *]) :: Constraint where
+  Units '[]                    = ()
+  Units (F unit z ': dfactors) = (Unit unit, Units dfactors)
+
 -- | Classifies well-formed list of unit factors, and permits calculating a
 -- conversion ratio for the purposes of LCSU conversions.
-class UnitFactor (units :: [Factor *]) where
+class (Units units) => UnitFactor (units :: [Factor *]) where
   canonicalConvRatioSpec :: Proxy units -> Rational
 
 instance UnitFactor '[] where

--- a/Data/Metrology/Validity.hs
+++ b/Data/Metrology/Validity.hs
@@ -38,10 +38,6 @@ type family MultUnitFactors (facts :: [Factor *]) where
 type family UnitOfDimFactors (dims :: [Factor *]) (lcsu :: LCSU *) :: * where
   UnitOfDimFactors dims lcsu = MultUnitFactors (LookupList dims lcsu)
 
-type family Units (dfactors :: [Factor *]) :: Constraint where
-  Units '[]                    = ()
-  Units (F unit z ': dfactors) = (Unit unit, Units dfactors)
-
 ------------------------------------------------
 -- Main validity functions
 ------------------------------------------------
@@ -51,7 +47,6 @@ type family ValidDLU (dfactors :: [Factor *]) (lcsu :: LCSU *) (unit :: *) where
   ValidDLU dfactors lcsu unit =
     ( dfactors ~ DimFactorsOf (DimOfUnit unit)
     , UnitFactor (LookupList dfactors lcsu)
-    , Units (LookupList dfactors lcsu)  -- needed only in GHC 8
     , Unit unit
     , UnitFactorsOf unit *~ LookupList dfactors lcsu )
 


### PR DESCRIPTION
When [trying to update](https://github.com/rimmington/units-attoparsec/commit/d9fc2abcea18d36da400a778ba1efa8f7a99c715) units-attoparsec, I ran into a constraint issue with [the build function](https://github.com/rimmington/units-attoparsec/blob/units24/Data/Units/SI/Units/Attoparsec/Text.hs#L66) in that package; specifically, I needed access to the `Units` type family. Then I noticed the type variable in `UnitFactor` is named `units`. So maybe this is better?